### PR TITLE
Remove Song Refresh option

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2.3.3
       - name: Tests
-        uses: reactivecircus/android-emulator-runner@v2.11.0
+        uses: reactivecircus/android-emulator-runner@v2.16.0
         with:
           api-level: 29
           script: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ on: push
 
 jobs:
   deploy:
-    name: Test Deploy
+    name: Deploy
     runs-on: ubuntu-latest
     container:
       image: circleci/android:api-30

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,31 +1,8 @@
-name: Continuous Integration
+name: Deploy
 on: push
 
 jobs:
-  test:
-    if: github.ref != 'refs/heads/master'
-    name: Test
-    runs-on: macos-10.15
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2.3.3
-      - name: Tests
-        uses: reactivecircus/android-emulator-runner@v2.16.0
-        with:
-          api-level: 29
-          script: |
-            ./gradlew test
-            ./gradlew connectedAndroidTest
-      - name: Archive Tests results
-        if: ${{ always() }}
-        uses: actions/upload-artifact@v2
-        with:
-          path: |
-            app/build/reports/androidTests/connected
-            app/build/reports/tests
-          retention-days: 7
-
-  testDeploy:
+  deploy:
     name: Test Deploy
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: Test
+on:
+  push:
+    branches-ignore: master
+
+jobs:
+  test:
+    name: Test
+    runs-on: macos-10.15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.3.3
+      - name: Tests
+        uses: reactivecircus/android-emulator-runner@v2.16.0
+        with:
+          api-level: 29
+          script: |
+            ./gradlew test
+            ./gradlew connectedAndroidTest
+      - name: Archive Tests results
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v2
+        with:
+          path: |
+            app/build/reports/androidTests/connected
+            app/build/reports/tests
+          retention-days: 7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2.3.3
       - name: Tests
-        uses: reactivecircus/android-emulator-runner@v2.16.0
+        uses: reactivecircus/android-emulator-runner@599839e4285455fff52cd8e3614575e02f1b673f
         with:
           api-level: 29
           script: |

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="1.8" />
+    <bytecodeTargetLevel target="11" />
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/.idea/runConfigurations.xml
+++ b/.idea/runConfigurations.xml
@@ -3,6 +3,7 @@
   <component name="RunConfigurationProducerService">
     <option name="ignoredProducers">
       <set>
+        <option value="com.android.tools.idea.compose.preview.runconfiguration.ComposePreviewRunConfigurationProducer" />
         <option value="org.jetbrains.plugins.gradle.execution.test.runner.AllInPackageGradleConfigurationProducer" />
         <option value="org.jetbrains.plugins.gradle.execution.test.runner.TestClassGradleConfigurationProducer" />
         <option value="org.jetbrains.plugins.gradle.execution.test.runner.TestMethodGradleConfigurationProducer" />

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "klalumiere.repertoire"
         minSdkVersion 22
         targetSdkVersion 30
-        versionCode 13
-        versionName "1.0"
+        versionCode 14
+        versionName "1.1"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         javaCompileOptions {
@@ -77,7 +77,6 @@ dependencies {
     implementation 'androidx.fragment:fragment-ktx:1.3.0-beta01' // Prevent crash when adding content
     implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.3.0-beta01'
     implementation 'androidx.recyclerview:recyclerview-selection:1.0.0'
-    implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
     implementation 'com.google.android.material:material:1.2.1' // content_main.xml ConstraintLayout
     kapt "androidx.room:room-compiler:$room_version"
     testImplementation 'android.arch.core:core-testing:1.1.1'

--- a/app/src/androidTest/java/com/example/repertoire/EndToEndTest.kt
+++ b/app/src/androidTest/java/com/example/repertoire/EndToEndTest.kt
@@ -150,21 +150,6 @@ class EndToEndTest {
         onView(withId(R.id.song_text_view)).check(matches(withSubstring("Happy Birthday to You")))
     }
 
-    @Test
-    fun canSwipeToRefreshSong() {
-        val intent = Intent(context, SongActivity::class.java).apply {
-            putExtra(SongActivity.SONG_NAME, "Happy Birthday")
-            putExtra(SongActivity.SONG_URI_AS_STRING, assetUri.toString())
-        }
-        val scenario = launchActivity<SongActivity>(intent)
-        // Here, we get the "Cannot read song" error message
-
-        scenario.onActivity { activity -> activity.injectAssetContentResolverForTests() }
-        onView(withId(R.id.song_refresher)).perform(swipeDown());
-
-        onView(withId(R.id.song_text_view)).check(matches(withSubstring("Happy Birthday to You")))
-    }
-
 
     @Before
     fun clearDatabase() {

--- a/app/src/main/java/com/example/repertoire/SongActivity.kt
+++ b/app/src/main/java/com/example/repertoire/SongActivity.kt
@@ -36,7 +36,6 @@ class SongActivity : AppCompatActivity() {
 
         song_title_text_view.text = song.name
         song_text_view.viewTreeObserver.addOnGlobalLayoutListener { onGlobalLayoutListener() }
-        song_refresher.setOnRefreshListener { refreshSong() }
     }
 
 
@@ -73,11 +72,6 @@ class SongActivity : AppCompatActivity() {
         songViewModel.songContent.observe(this, songContentObserver)
         songContentAdapter?.getRenderedSongContent()?.observe(this, renderedSongContentObserver)
         songViewModel.setSongContent(Uri.parse(song.uri), lifecycle.coroutineScope)
-    }
-
-    private fun refreshSong() {
-        songViewModel.setSongContent(Uri.parse(song.uri), lifecycle.coroutineScope)
-        song_refresher.isRefreshing = false
     }
 
     private lateinit var song: Song

--- a/app/src/main/res/layout/activity_song.xml
+++ b/app/src/main/res/layout/activity_song.xml
@@ -6,10 +6,6 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     tools:context=".SongActivity">
 
-    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
-            android:id="@+id/song_refresher"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent">
     <ScrollView
             android:layout_width="match_parent"
             android:layout_height="match_parent">
@@ -44,6 +40,5 @@
         </androidx.constraintlayout.widget.ConstraintLayout>
 
     </ScrollView>
-    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:4.2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip


### PR DESCRIPTION
It didn't work well enough. In the future, songs will be added directly
to the app database, hence, refreshing them won't be possible.

From the best of my knowledge,

- [x] The changeset is required (remember, code is a debt)
- [x] The changeset integrates well into the codebase
- [x] The changeset has automated tests
- [x] The changeset has no obvious performance issues
- [x] The changeset is safe for exceptions and corner cases
- [x] The changeset contains no security issues (unsanitized parameters, buffer overflow, etc)
- [x] The changeset's code is easy to understand for any developer with the appropriate domain knowledge
