### PR TITLE
Regular version bump + remove schedule

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,5 @@
 on:
   push: {}
-  schedule:
-    - cron:  '0 0 1 3,6,9,12 *'
 
 jobs:
   deploy:

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,7 +12,7 @@ android {
         applicationId = "klalumiere.repertoire"
         minSdk = 22
         targetSdk = 35
-        versionCode = 26
+        versionCode = 27
         versionName = "2.1.2"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
Scheduled was not useful. It forced me to update the app every month because the workflow would be disabled every 60 days. However, Google Play requires an update every year. A manual reminder each 6 month will do.